### PR TITLE
Investigate incorrect stop-loss alerts

### DIFF
--- a/스탑로스_알림_문제_해결.md
+++ b/스탑로스_알림_문제_해결.md
@@ -1,0 +1,76 @@
+# 스탑로스 알림 문제 분석 및 해결 방안
+
+## 문제 상황
+- ADA와 SOL 포지션이 실제로는 살아있는데 디스코드에서 계속 스탑로스 알림이 발생
+- 포지션은 존재하지만 스탑로스 걸렸다는 메시지가 반복적으로 전송됨
+
+## 원인 분석
+
+### 1. 동기화 문제
+- 거래소에서 실제 포지션과 내부 캐시(`self.positions`) 간의 동기화 지연
+- 스탑로스 주문이 실제로 체결되어 포지션이 닫혔는데, 내부 캐시가 아직 업데이트되지 않음
+
+### 2. 포지션 종료 실패
+- 스탑로스 알림이 발생한 후 `close_position_market()` 함수가 실패할 수 있음
+- 네트워크 오류, API 오류 등으로 인한 포지션 종료 실패
+
+### 3. 중복 알림 방지 로직 부재
+- 동일한 스탑로스 조건에서 반복적으로 알림이 발생하는 문제
+
+## 해결 방안
+
+### 1. 실제 포지션 존재 확인
+```python
+# 스탑로스 알림 발생 전 실제 포지션 확인
+live = get_open_position(symbol)
+if live and abs(live.get("entry", 0)) > 0:
+    # 실제 포지션이 존재할 때만 알림 발생
+    send_discord_message(f"[STOP LOSS] {symbol} @ {mark_price:.2f}", "aggregated")
+    self.close(symbol)
+else:
+    # 포지션이 없으면 캐시만 정리
+    self.positions.pop(symbol, None)
+    self._cooldowns[symbol] = time.time()
+```
+
+### 2. 스탑로스 알림 중복 방지
+```python
+# 30초 간격으로 스탑로스 알림 제한
+now = time.time()
+last_alert = self._sl_alerts.get(symbol, 0)
+if now - last_alert > 30:  # 30초마다 최대 1번 알림
+    send_discord_message(f"[STOP LOSS] {symbol} @ {mark_price:.2f}", "aggregated")
+    self._sl_alerts[symbol] = now
+```
+
+### 3. 포지션 상태 정리
+```python
+# 포지션 종료 시 알림 상태도 함께 정리
+self._cooldowns[symbol] = time.time()
+self._sl_alerts.pop(symbol, None)
+```
+
+## 수정된 코드 적용 내용
+
+### 1. `core/position.py` 수정사항
+- `__init__` 메서드에 `self._sl_alerts: Dict[str, float] = {}` 추가
+- `monitor_position` 메서드에서 스탑로스 알림 전 실제 포지션 확인 로직 추가
+- 30초 간격 중복 알림 방지 로직 추가
+- `close` 메서드에서 스탑로스 알림 상태 정리 로직 추가
+
+### 2. 주요 변경 사항
+- 스탑로스 조건 충족 시 실제 거래소 포지션 확인 후 알림 발생
+- 동일 심볼에 대해 30초 간격으로 알림 제한
+- 포지션 종료 시 모든 관련 상태 정리
+
+## 기대 효과
+1. **허위 알림 방지**: 실제 포지션이 없는 경우 스탑로스 알림 발생 방지
+2. **중복 알림 방지**: 동일 조건에서 반복적인 알림 발생 방지
+3. **상태 동기화**: 내부 캐시와 실제 거래소 포지션 간 동기화 개선
+4. **안정성 향상**: 포지션 관리 시스템의 전반적인 안정성 향상
+
+## 추가 권장사항
+1. 로그 모니터링을 통해 스탑로스 알림 발생 패턴 확인
+2. 거래소 API 응답 시간 및 오류율 모니터링
+3. 포지션 동기화 주기 조정 (현재 15초, 필요시 단축 가능)
+4. 디스코드 웹훅 응답 상태 확인 로직 추가


### PR DESCRIPTION
Implement stop-loss alert deduplication and pre-check to prevent false and repetitive Discord notifications.

Previously, stop-loss alerts could be triggered even if the actual position on the exchange was no longer open or if the internal cache was out of sync, leading to misleading and repeated notifications. This PR ensures alerts are sent only when a live position exists and limits their frequency.