### PR TITLE
오류 발생에도 포지션 잡히는 문제 해결

### DIFF
--- a/PENGUUSDT_time_variable_error_analysis.md
+++ b/PENGUUSDT_time_variable_error_analysis.md
@@ -1,0 +1,100 @@
+# PENGUUSDT 포지션 등록 오류 분석 및 해결방안
+
+## 문제 상황
+- **오류 메시지**: `❌ [ERROR] PENGUUSDT 포지션 등록 실패: cannot access local variable 'time' where it is not associated with a value`
+- **상태**: 오류는 발생했지만 포지션은 정상적으로 생성됨
+- **발생 위치**: `core/position.py`의 `enter` 메소드 내부
+
+## 원인 분석
+
+### 1. 오류 발생 지점
+- **파일**: `core/position.py`
+- **라인**: 203번 라인 `"_created": time.time()`
+- **컨텍스트**: `PositionManager.enter()` 메소드 실행 중
+
+### 2. 변수 스코핑 문제
+```python
+# core/position.py 상단
+import time  # 모듈 import
+
+# enter 메소드 내부 (라인 203)
+"_created": time.time(),  # 여기서 오류 발생
+```
+
+### 3. 가능한 원인들
+1. **로컬 변수 섀도잉**: 함수 내부에서 `time` 변수가 선언되어 모듈을 가림
+2. **비동기 실행 컨텍스트**: 비동기 환경에서의 변수 스코프 문제
+3. **예외 처리 중 상태 변경**: 예외 발생 시 변수 상태가 변경됨
+
+## 코드 검토 결과
+
+### 현재 코드 구조
+```python
+# main.py 라인 407
+except Exception as e:
+    print(f"[ERROR] {symbol} {htf_tf}/{ltf_tf} → {e}", "aggregated")
+```
+
+### 포지션 등록 플로우
+```python
+# main.py 라인 377
+pm.enter(
+    symbol,
+    direction,
+    entry,
+    sl,
+    tp,
+    basis=basis,
+    protective=prot_lv,
+)
+```
+
+## 해결 방안
+
+### 1. 즉시 수정 (권장)
+`core/position.py`에서 `time` 모듈 사용 시 명시적 참조 사용:
+
+```python
+# 현재 코드 (라인 203)
+"_created": time.time(),
+
+# 수정된 코드
+import time as time_module  # 상단에서 변경
+"_created": time_module.time(),  # 사용 시 명시적 참조
+```
+
+### 2. 대안 방법
+datetime 모듈 사용으로 변경:
+```python
+from datetime import datetime
+"_created": datetime.now().timestamp(),
+```
+
+### 3. 디버깅 강화
+예외 처리 시 더 상세한 정보 제공:
+```python
+except Exception as e:
+    import traceback
+    error_details = traceback.format_exc()
+    print(f"[ERROR] {symbol} 포지션 등록 실패: {e}")
+    print(f"[DEBUG] 상세 오류:\n{error_details}")
+```
+
+## 임시 조치
+현재 포지션은 정상적으로 생성되고 있으므로, 급하게 수정하지 않아도 거래에는 문제없음. 하지만 로그 정확성과 디버깅을 위해 수정 권장.
+
+## 수정 우선순위
+1. **높음**: `time` 모듈 참조 방식 변경
+2. **중간**: 예외 처리 로직 개선
+3. **낮음**: 전체적인 오류 처리 체계 개선
+
+## 테스트 방법
+수정 후 PENGUUSDT 포지션 진입 시 오류 메시지 없이 정상 동작하는지 확인:
+```
+[ENTRY] PENGUUSDT | LONG @ 0.0307 | SL: 0.0303 | TP: 0.0315
+```
+
+## 추가 권장사항
+1. 전체 코드베이스에서 유사한 변수 섀도잉 문제 검토
+2. 비동기 환경에서의 변수 스코프 관리 개선
+3. 예외 처리 시 컨텍스트 정보 보강

--- a/core/position.py
+++ b/core/position.py
@@ -1,6 +1,6 @@
 # core/position.py
 
-import time
+import time as time_module
 from typing import Dict, Optional
 from decimal import Decimal, ROUND_DOWN, ROUND_UP
 # ── pandas 타입 힌트/연산에 사용 ──────────────────────
@@ -101,7 +101,7 @@ class PositionManager:
     def in_cooldown(self, symbol: str) -> bool:
         """True  → 아직 쿨-다운 시간 미경과"""
         t = self._cooldowns.get(symbol)
-        return t is not None and (time.time() - t) < self.COOLDOWN_SEC
+        return t is not None and (time_module.time() - t) < self.COOLDOWN_SEC
 
     # 현재 내부에서 '열려-있다'고 간주되는 심볼 리스트
     def active_symbols(self) -> list[str]:
@@ -201,7 +201,7 @@ class PositionManager:
             "protective_level": protective,          # ← 최초부터 보유
             "mss_triggered": False,
             "sl_order_id": None,
-            "_created": time.time(),        # → 트레일링 SL grace‑period 용
+            "_created": time_module.time(),        # → 트레일링 SL grace‑period 용
         }
         on_entry(symbol, direction, entry, sl, tp)   # ★ 호출
 
@@ -372,7 +372,7 @@ class PositionManager:
                     "aggregated",
                 )
                 # ▸ ❶ 60 초 쿨다운 해시 저장
-                pos["_mss_skip_until"] = time.time() + 60
+                pos["_mss_skip_until"] = time_module.time() + 60
                 # ▸ ❷ 보호선·MSS 플래그 초기화
                 pos["protective_level"] = None
                 pos["mss_triggered"]    = False
@@ -482,7 +482,7 @@ class PositionManager:
             print(f"[INFO] {symbol} SL 이미 소멸 → MARKET 청산 생략")
             # 내부 포지션만 제거하고 쿨-다운
             pos = self.positions.pop(symbol, None)
-            self._cooldowns[symbol] = time.time()
+            self._cooldowns[symbol] = time_module.time()
             return
         
         pos = self.positions.pop(symbol, None)
@@ -520,7 +520,7 @@ class PositionManager:
         on_exit(symbol, exit_price, datetime.now(timezone.utc))
 
         # ▸ 쿨-다운 시작
-        self._cooldowns[symbol] = time.time()
+        self._cooldowns[symbol] = time_module.time()
 
     def init_position(self, symbol: str, direction: str, entry: float, sl: float, tp: float):
         self.positions[symbol] = {
@@ -563,7 +563,7 @@ class PositionManager:
         if not pos.get("half_exit"):
             return
         # ② half_exit 후라도 *진입 30 초 이내* 는 무시 (급격한 노이즈 방어)
-        if time.time() - pos.get("_created", 0) < 30:
+        if time_module.time() - pos.get("_created", 0) < 30:
             return
         direction = pos['direction']
         current_sl = pos['sl']


### PR DESCRIPTION
Rename `time` module import to `time_module` to resolve `cannot access local variable 'time'` error.

The error `cannot access local variable 'time' where it is not associated with a value` was occurring in `core/position.py` despite `import time` being present. This indicates a variable shadowing issue where a local variable named `time` was inadvertently declared, hiding the imported `time` module. Renaming the import ensures the correct module is always referenced. The position was still created successfully, suggesting the error was primarily in logging or notification rather than core functionality.